### PR TITLE
DevOps code ownership for workflows

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,3 +6,6 @@
 
 # Default file owners.
 * @bitwarden/team-leads-eng
+
+# DevOps for Actions and other workflow changes.
+.github/workflows @bitwarden/dept-devops


### PR DESCRIPTION
## 🎟️ Tracking

Internal change.

## 🚧 Type of change

-   🎂 Other

## 📔 Objective

Adds DevOps as a code owner for workflows as they take primary responsibility for configurations. In practice this will be shared for domain and their review, but it's wise to define the ownership.

## 📋 Code changes

-   **.github/CODEOWNERS:** Entry for GitHub workflows.

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
