### PR TITLE
Explicitly match managers

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -15,6 +15,7 @@
   "packageRules": [
     {
       "groupName": "{{manager}}",
+      "matchManagers": ["cargo", "github-actions", "npm", "nuget"],
       "matchPackagePatterns": ["*"],
       "matchUpdateTypes": ["minor", "patch"]
     }


### PR DESCRIPTION
## 🎟️ Tracking

Internal change.

## 🚧 Type of change

-   🎂 Other

## 📔 Objective

Per https://github.com/renovatebot/renovate/discussions/16419 and some other info, the prior approach needs additional qualification to split rollup PRs by manager.

## 📋 Code changes

-   **.github/renovate.json:** Manager property additional that matches the enabled managers.

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
