### PR TITLE
Added explicit contributing docs reference to template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -36,7 +36,7 @@
 - Used internationalization (i18n) for all UI strings
 - CI builds passed
 - Communicated to DevOps any deployment requirements
-- Updated any necessary documentation (Confluence, https://contributing.bitwarden.com) or informed the documentation team
+- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team
 
 ## 🦮 Reviewer guidelines
 


### PR DESCRIPTION
## 🚧 Type of change

<!-- Choose those applicable and remove the others. -->

- 🎂 Other

## 📔 Objective

In a retro, we discussed the benefit of calling out that we should look to ensure any documentation is up to date when submitting a PR.  This change will explicitly reference Confluence and our contributing docs.

## 📋 Code changes

- **PULL_REQUEST_TEMPLATE.md:** Added explicit documentation references.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
