### PR TITLE
Workflow for PR run checks to manage secret usage

### DIFF
--- a/.github/workflows/check-run.yml
+++ b/.github/workflows/check-run.yml
@@ -2,6 +2,8 @@ name: Check PR run
 
 on:
   workflow_call:
+  pull_request_target:
+    types: [opened, synchronize]
 
 permissions: read-all
 

--- a/.github/workflows/check-run.yml
+++ b/.github/workflows/check-run.yml
@@ -2,8 +2,6 @@ name: Check PR run
 
 on:
   workflow_call:
-  pull_request_target:
-    types: [opened, synchronize]
 
 permissions: read-all
 

--- a/.github/workflows/check-run.yml
+++ b/.github/workflows/check-run.yml
@@ -1,8 +1,6 @@
 name: Check PR run
 
 on:
-  pull_request_target:
-    types: [opened, synchronize]
   workflow_call:
 
 permissions: read-all

--- a/.github/workflows/check-run.yml
+++ b/.github/workflows/check-run.yml
@@ -1,0 +1,20 @@
+name: Check PR run
+
+on:
+  pull_request_target:
+    types: [opened, synchronize]
+  workflow_call:
+
+permissions: read-all
+
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Check access
+        if: ${{ github.event.pull_request.author_association != 'COLLABORATOR' && github.event.pull_request.author_association != 'OWNER' }}
+        run: |
+          echo "Event not triggered by a collaborator."
+          exit 1

--- a/.github/workflows/check-run.yml
+++ b/.github/workflows/check-run.yml
@@ -13,8 +13,19 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - name: Check access
-        if: ${{ github.event.pull_request.author_association != 'COLLABORATOR' && github.event.pull_request.author_association != 'OWNER' }}
+      - name: Get user permission
+        id: get-permission
+        uses: actions-cool/check-user-permission@956b2e73cdfe3bcb819bb7225e490cb3b18fd76e # v2.2.1
+        with:
+          require: write
+          username: ${{ github.triggering_actor }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check user permission
+        if: steps.get-permission.outputs.require-result == 'false'
         run: |
-          echo "Event not triggered by a collaborator."
+          echo "User ${{ github.triggering_actor }} does not have the necessary access for this repository."
+          echo "Current permission level is ${{ steps.get-permission.outputs.user-permission }}."
+          echo "Job originally triggered by ${{ github.actor }}."
           exit 1

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -12,9 +12,15 @@ on:
 permissions: read-all
 
 jobs:
+  check-run:
+    name: Check PR run
+    if: github.event_name == 'pull_request'
+    uses: ./.github/workflows/check-run.yml
+
   sast:
     name: SAST scan
     runs-on: ubuntu-22.04
+    needs: check-run
     permissions:
       security-events: write
 
@@ -42,6 +48,7 @@ jobs:
   quality:
     name: Quality scan
     runs-on: ubuntu-22.04
+    needs: check-run
 
     steps:
       - name: Check out repo

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -15,7 +15,7 @@ permissions: read-all
 jobs:
   check-run:
     name: Check PR run
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request_target'
     uses: ./.github/workflows/check-run.yml
 
   sast:

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -8,6 +8,7 @@ on:
       - "rc"
       - "hotfix-rc"
   pull_request_target:
+    types: [opened, synchronize]
 
 permissions: read-all
 

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -7,6 +7,7 @@ on:
       - "main"
       - "rc"
       - "hotfix-rc"
+  pull_request:
   pull_request_target:
     types: [opened, synchronize]
 
@@ -15,6 +16,7 @@ permissions: read-all
 jobs:
   check-run:
     name: Check PR run
+    if: github.event_name == 'pull_request_target'
     uses: ./.github/workflows/check-run.yml
 
   sast:

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -7,7 +7,8 @@ on:
       - "main"
       - "rc"
       - "hotfix-rc"
-  pull_request:
+  pull_request_target:
+    types: [opened, synchronize]
 
 permissions: read-all
 
@@ -27,6 +28,8 @@ jobs:
     steps:
       - name: Check out repo
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          ref: ${{  github.event.pull_request.head.sha }}
 
       - name: Scan with Checkmarx
         uses: checkmarx/ast-github-action@749fec53e0db0f6404a97e2e0807c3e80e3583a7 #2.0.23
@@ -55,6 +58,7 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           fetch-depth: 0
+          ref: ${{  github.event.pull_request.head.sha }}
 
       - name: Scan with SonarCloud
         uses: sonarsource/sonarcloud-github-action@49e6cd3b187936a73b8280d59ffd9da69df63ec9 # v2.1.1

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -8,7 +8,6 @@ on:
       - "rc"
       - "hotfix-rc"
   pull_request_target:
-    types: [opened, synchronize]
 
 permissions: read-all
 

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Scan with Checkmarx
         uses: checkmarx/ast-github-action@749fec53e0db0f6404a97e2e0807c3e80e3583a7 #2.0.23
         env:
-          INCREMENTAL: "${{ github.event_name == 'pull_request' && '--sast-incremental' || '' }}"
+          INCREMENTAL: "${{ contains(github.event_name, 'pull_request') && '--sast-incremental' || '' }}"
         with:
           project_name: ${{ github.repository }}
           cx_tenant: ${{ secrets.CHECKMARX_TENANT }}

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -15,7 +15,6 @@ permissions: read-all
 jobs:
   check-run:
     name: Check PR run
-    if: github.event_name == 'pull_request_target'
     uses: ./.github/workflows/check-run.yml
 
   sast:

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -16,7 +16,6 @@ permissions: read-all
 jobs:
   check-run:
     name: Check PR run
-    if: github.event_name == 'pull_request_target'
     uses: ./.github/workflows/check-run.yml
 
   sast:

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -7,7 +7,6 @@ on:
       - "main"
       - "rc"
       - "hotfix-rc"
-  pull_request:
   pull_request_target:
     types: [opened, synchronize]
 


### PR DESCRIPTION
## 🎟️ Tracking

Internal change.

## 📔 Objective

See https://michaelheap.com/access-secrets-from-forks/ for background. This provides a `check-run.yml` reusable workflow that becomes a `need` for the two new scanning workflows that use secrets. When invoked by non-members of the organization, the check workflow will fail and short-circuit the scanners, therefore not failing on secret access. A member can then review the change for safety and manually run the workflows that failed or were skipped. This can serve as a pattern across all our repos that use secrets in workflows and we better collaborate with external contributors.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
