### PR TITLE
Add k6 GitHub workflow

### DIFF
--- a/.github/workflows/test-load-k6.yaml
+++ b/.github/workflows/test-load-k6.yaml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   run-tests:
+    name: Run k6 tests
     runs-on: ubuntu-24.04
     services:
       # Datadog agent for collecting OTEL metrics from k6
@@ -35,16 +36,16 @@ jobs:
           --pid host
     env:
       # K6 and Datadog system configuration
-      DOCKER_CONTENT_TRUST: 1
-      K6_OTEL_EXPORTER_TYPE: http
-      K6_OTEL_HTTP_EXPORTER_INSECURE: true
-      K6_OTEL_METRIC_PREFIX: k6_
-      K6_FLAGS: >-
+      _DOCKER_CONTENT_TRUST: 1
+      _K6_OTEL_EXPORTER_TYPE: http
+      _K6_OTEL_HTTP_EXPORTER_INSECURE: true
+      _K6_OTEL_METRIC_PREFIX: k6_
+      _K6_FLAGS: >-
         --tag test-id=${{ github.ref_name }}
         -o experimental-opentelemetry
       
       # Paths to your k6 load tests
-      K6_LOAD_TESTS_PATHS: >-
+      _K6_LOAD_TESTS_PATHS: >-
         perf/load/*.js
     steps:
       - name: Check out repo
@@ -59,5 +60,5 @@ jobs:
         uses: grafana/run-k6-action@c6b79182b9b666aa4f630f4a6be9158ead62536e # v1.2.0
         continue-on-error: true
         with:
-          path: ${{ env.K6_LOAD_TESTS_PATHS }}
-          flags: ${{ env.K6_FLAGS }}
+          path: ${{ env._K6_LOAD_TESTS_PATHS }}
+          flags: ${{ env._K6_FLAGS }}

--- a/.github/workflows/test-load-k6.yaml
+++ b/.github/workflows/test-load-k6.yaml
@@ -14,7 +14,7 @@ jobs:
     services:
       # Datadog agent for collecting OTEL metrics from k6
       datadog:
-        image: datadog/agent:7-full
+        image: datadog/agent:7-full@sha256:a81b9f2e5ad5b8d11a560d8716fcc1139c105a72d5157260f7034cea7a5103eb
         ports:
           - 4317:4317
           - 5555:5555

--- a/.github/workflows/test-load-k6.yaml
+++ b/.github/workflows/test-load-k6.yaml
@@ -1,4 +1,4 @@
-name: k6 Load Test
+name: Load Test
 
 on:
   push:

--- a/.github/workflows/test-load-k6.yaml
+++ b/.github/workflows/test-load-k6.yaml
@@ -44,7 +44,7 @@ jobs:
         -o experimental-opentelemetry
       
       # Paths to your k6 load tests
-      K6_LOADTESTS_PATHS: >-
+      K6_LOAD_TESTS_PATHS: >-
         perf/load/*.js
     steps:
       - name: Check out repo
@@ -60,5 +60,5 @@ jobs:
         id: k6-test
         continue-on-error: true
         with:
-          path: ${{ env.K6_LOADTESTS_PATHS }}
+          path: ${{ env.K6_LOAD_TESTS_PATHS }}
           flags: ${{ env.K6_FLAGS }}

--- a/.github/workflows/test-load-k6.yaml
+++ b/.github/workflows/test-load-k6.yaml
@@ -1,0 +1,64 @@
+name: k6 Load Test
+
+on:
+  push:
+    branches:
+      - "main"
+      - "rc"
+      - "hotfix-rc"
+
+jobs:
+  run-tests:
+    runs-on: ubuntu-24.04
+    services:
+      # Datadog agent for collecting OTEL metrics from k6
+      datadog:
+        image: datadog/agent:7-full
+        ports:
+          - 4318:4318
+          - 5555:5555
+        env:
+          DD_SITE: us3.datadoghq.com
+          DD_API_KEY: ${{ secrets.DD_API_KEY }}
+          DD_DOGSTATSD_NON_LOCAL_TRAFFIC: 1
+          DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_HTTP_ENDPOINT: 0.0.0.0:4318
+          DD_HEALTH_PORT: 5555
+          HOST_PROC: /proc
+        options: >-
+          --volume /var/run/docker.sock:/var/run/docker.sock:ro
+          --volume /sys/fs/cgroup/:/host/sys/fs/cgroup:ro
+          --health-cmd "curl -f http://localhost:5555/health || exit 1"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+          --health-start-period 30s
+          --pid host
+    env:
+      # K6 and Datadog system configuration
+      DOCKER_CONTENT_TRUST: 1
+      K6_OTEL_EXPORTER_TYPE: http
+      K6_OTEL_HTTP_EXPORTER_INSECURE: true
+      K6_OTEL_METRIC_PREFIX: k6_
+      K6_FLAGS: >-
+        --tag test-id=${{ github.ref_name }}
+        -o experimental-opentelemetry
+      
+      # Paths to your k6 load tests
+      K6_LOADTESTS_PATHS: >-
+        perf/load/*.js
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Setup k6
+        uses: grafana/setup-k6-action@ffe7d7290dfa715e48c2ccc924d068444c94bde2 # v1.1.0
+
+      - name: Run k6 tests
+        uses: grafana/run-k6-action@c6b79182b9b666aa4f630f4a6be9158ead62536e # v1.2.0
+        id: k6-test
+        continue-on-error: true
+        with:
+          path: ${{ env.K6_LOADTESTS_PATHS }}
+          flags: ${{ env.K6_FLAGS }}

--- a/.github/workflows/test-load-k6.yaml
+++ b/.github/workflows/test-load-k6.yaml
@@ -16,13 +16,13 @@ jobs:
       datadog:
         image: datadog/agent:7-full
         ports:
-          - 4318:4318
+          - 4317:4317
           - 5555:5555
         env:
           DD_SITE: us3.datadoghq.com
           DD_API_KEY: ${{ secrets.DD_API_KEY }}
           DD_DOGSTATSD_NON_LOCAL_TRAFFIC: 1
-          DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_HTTP_ENDPOINT: 0.0.0.0:4318
+          DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_GRPC_ENDPOINT: 0.0.0.0:4317
           DD_HEALTH_PORT: 5555
           HOST_PROC: /proc
         options: >-
@@ -37,8 +37,7 @@ jobs:
     env:
       # K6 and Datadog system configuration
       _DOCKER_CONTENT_TRUST: 1
-      _K6_OTEL_EXPORTER_TYPE: http
-      _K6_OTEL_HTTP_EXPORTER_INSECURE: true
+      _K6_OTEL_GRPC_EXPORTER_INSECURE: true
       _K6_OTEL_METRIC_PREFIX: k6_
       _K6_FLAGS: >-
         --tag test-id=${{ github.ref_name }}

--- a/.github/workflows/test-load-k6.yaml
+++ b/.github/workflows/test-load-k6.yaml
@@ -53,7 +53,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Setup k6
+      - name: Set up k6
         uses: grafana/setup-k6-action@ffe7d7290dfa715e48c2ccc924d068444c94bde2 # v1.1.0
 
       - name: Run k6 tests

--- a/.github/workflows/test-load-k6.yaml
+++ b/.github/workflows/test-load-k6.yaml
@@ -57,7 +57,6 @@ jobs:
 
       - name: Run k6 tests
         uses: grafana/run-k6-action@c6b79182b9b666aa4f630f4a6be9158ead62536e # v1.2.0
-        id: k6-test
         continue-on-error: true
         with:
           path: ${{ env.K6_LOAD_TESTS_PATHS }}


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
Adds a template to be used for running k6 load tests for projects for the desired `K6_LOAD_TESTS_PATHS`. 
k6 is configured to export OTEL metrics directly into Datadog using the [GitHub service container](https://docs.github.com/en/actions/use-cases-and-examples/using-containerized-services/about-service-containers).


<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
