### PR TITLE
[PM-36047] Set an owner for the CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,6 +7,9 @@
 # Default file owners
 * @bitwarden/dept-architecture
 
+# CODEOWNERS owners
+.github/CODEOWNERS @bitwarden/tech-leads
+
 # Claude related files
 .claude/ @bitwarden/team-ai-sme
 .github/workflows/respond.yml @bitwarden/team-ai-sme


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-36047

## 📔 Objective

For some existing repositories, there is no owner for the CODEOWNERS file itself. This presents a couple of concerns that were discussed in the recent April 28 Tech Leads meeting. The main initial concern is that a team’s ownership can change without them knowing or being approvers of the change.

This could be fixed in multiple ways, but two were discussed:

1. CODEOWNERS changes require approval from all teams whose ownership is changing. This is the better solution, but GitHub doesn’t seem to provide this capability. Something custom would have to be created, so this option is more effort.
2. CODEOWNERS changes require approval from the Tech Lead group. This is a less ideal solution compared to `#1`, but it should help provide more approval from the tech lead owners of files, and give them notifications on any changes.

Notably, for this `template` repository, this change would remove architecture as the default owners for new repositories. This was not discussed in the meeting, so opinions on this are definitely welcome (in addition to this change overall).