### PR TITLE
ci: add Prettier and CSpell linting via git hooks and CI

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/streetsidesoftware/cspell/main/cspell.schema.json",
   "version": "0.2",
-  "words": ["Bitwarden"],
+  "unknownWords": "report-common-typos",
   "flagWords": [],
   "ignorePaths": [
     ".vscode",

--- a/.gitconfig
+++ b/.gitconfig
@@ -1,3 +1,3 @@
 [hook "linter"]
     event = pre-commit
-    command = echo "Add linter in ./gitconfig"
+    command = sh .githooks/pre-commit

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,29 @@
+#!/usr/bin/env sh
+#
+# Pre-commit linter: formats and spell-checks staged files.
+#   - Prettier (--check) on staged Markdown, JSON, JSON5, and YAML
+#   - CSpell on staged Markdown
+#
+# Wired up through .gitconfig ([hook "linter"]). Enable it once per clone by
+# running the following from the repo root:
+#
+#   git config set --local include.path "../.gitconfig"
+#
+# Requires Node.js (>=18); the tools are fetched on demand via `npx --yes`.
+
+set -eu
+
+staged_files=$(git diff --cached --name-only --diff-filter=ACMR -- '*.md' '*.json' '*.json5' '*.yml' '*.yaml')
+
+if [ -n "$staged_files" ]; then
+  # Word-splitting is intentional: pass each newline-separated path as an argument.
+  # shellcheck disable=SC2086
+  npx --yes prettier@3.9.1 --check $staged_files
+fi
+
+staged_md=$(git diff --cached --name-only --diff-filter=ACMR -- '*.md')
+
+if [ -n "$staged_md" ]; then
+  # shellcheck disable=SC2086
+  npx --yes cspell@10.0.1 --no-progress --gitignore $staged_md
+fi

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,8 +1,35 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>bitwarden/renovate-config"],
-  "enabledManagers": ["cargo", "docker-compose", "dockerfile", "github-actions", "npm", "nuget"],
+  "enabledManagers": [
+    "cargo",
+    "custom.regex",
+    "docker-compose",
+    "dockerfile",
+    "github-actions",
+    "npm",
+    "nuget"
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Pinned npx tool versions in the lint workflow and git hooks",
+      "fileMatch": [
+        "^\\.github/workflows/lint\\.yml$",
+        "^\\.githooks/pre-commit$"
+      ],
+      "matchStrings": [
+        "(?<depName>prettier|cspell)@(?<currentValue>\\d+\\.\\d+\\.\\d+)"
+      ],
+      "datasourceTemplate": "npm"
+    }
+  ],
   "packageRules": [
+    {
+      "groupName": "lint tooling",
+      "matchManagers": ["custom.regex"],
+      "matchPackageNames": ["prettier", "cspell"]
+    },
     {
       "groupName": "cargo minor",
       "matchManagers": ["cargo"],

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,50 @@
+name: Lint
+
+# Keep the Prettier and CSpell tooling here in sync with the pre-commit linter
+# in .githooks/pre-commit (versions, file globs, and flags) so local commits and
+# CI enforce the same rules. Renovate bumps both together via .github/renovate.json.
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  format:
+    name: Prettier
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Set up Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+
+      - name: Check formatting
+        run: npx --yes prettier@3.9.1 --check "**/*.{md,json,json5,yml,yaml}"
+
+  spell:
+    name: CSpell
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Set up Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+
+      - name: Check spelling
+        run: npx --yes cspell@10.0.1 --no-progress --gitignore "**/*.md"

--- a/README.md
+++ b/README.md
@@ -4,11 +4,18 @@ This repository serves as a template for others and establishes very basic struc
 
 ## Hooks
 
-Hooks are centrally configured for the repo in the `.gitconfig` file.
+Hooks are centrally configured for the repo in the `.gitconfig` file. The `pre-commit` hook
+([`.githooks/pre-commit`](.githooks/pre-commit)) runs [Prettier](https://prettier.io) (`--check`) on
+staged Markdown, JSON, JSON5, and YAML, and [CSpell](https://cspell.org) against staged Markdown to
+catch common typos; the spell-checker's settings live in `.cspell.json`. The same checks run in CI on
+every pull request via the [Lint workflow](.github/workflows/lint.yml), and the pinned tool versions —
+in both the hook and the workflow — are kept current by Renovate.
 
-If you configure a linter you will want to include docs to have contributors run the following
-command:
+Hooks are opt-in per clone. Enable them once, from the repo root:
 
 ```bash
 git config set --local include.path "../.gitconfig"
 ```
+
+Running the hook requires [Node.js](https://nodejs.org) (>=18); CSpell itself is fetched on demand
+via `npx`.

--- a/README.md
+++ b/README.md
@@ -17,5 +17,13 @@ Hooks are opt-in per clone. Enable them once, from the repo root:
 git config set --local include.path "../.gitconfig"
 ```
 
-Running the hook requires [Node.js](https://nodejs.org) (>=18); CSpell itself is fetched on demand
-via `npx`.
+Running the hook requires [Node.js](https://nodejs.org) (>=18); the tools are fetched on demand via
+`npx`.
+
+## Customizing the linter
+
+Because this is a template, treat the linter as a starting point and adjust it for your repo. The file
+extensions are the most likely thing to change: Prettier checks Markdown, JSON, JSON5, and YAML, and
+CSpell checks Markdown. If you change those globs, update both
+[`.githooks/pre-commit`](.githooks/pre-commit) and the [Lint workflow](.github/workflows/lint.yml) so
+local commits and CI stay in sync. Swapping tools or changing the pinned versions works the same way.


### PR DESCRIPTION
## 🎟️ Tracking

No associated Jira ticket — repository tooling change.

## 📔 Objective

Wire up Prettier and CSpell linting for the template repo, enforced both locally (pre-commit git hook) and in CI on every pull request.

- **`.githooks/pre-commit`** — runs Prettier (`--check`) on staged Markdown/JSON/JSON5/YAML and CSpell on staged Markdown. Invoked through the existing config-based `[hook "linter"]` in `.gitconfig`; enable per clone with `git config set --local include.path "../.gitconfig"`.
- **`.cspell.json`** — switched to `"unknownWords": "report-common-typos"` so only common typos (not every proper noun) are flagged, mirroring bitwarden/tech-breakdowns#17.
- **`.github/workflows/lint.yml`** — new Lint workflow running the same Prettier + CSpell checks on every PR, on Node 24 (LTS), with SHA-pinned `actions/checkout` v7.0.0 and `actions/setup-node` v6.4.0. A comment notes it must mirror the git hook.
- **`.github/renovate.json`** — added a `custom.regex` manager that keeps the pinned `prettier@` / `cspell@` versions in the hook and the workflow in sync, grouped as a single "lint tooling" PR.
- **`README.md`** — documents the hook, the CI check, and how to enable hooks locally.

Tool versions are pinned and identical across the hook and workflow (`prettier@3.9.1`, `cspell@10.0.1`); Renovate bumps them together.