### PR TITLE
Docs/documentation standard compliance

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,3 +1,58 @@
-# Claude Code Configuration
+# Repository name - Claude Code Configuration
 
-TODO: see https://bitwarden.atlassian.net/wiki/x/LgDMaQ for configuration tips to complete the `.claude/CLAUDE.md` file
+<!--
+Template guidance — delete this comment when customizing your new repo.
+
+Run /bitwarden-init:init to generate this file from an analysis of your
+codebase. It fills the sections below and requires these exact headings:
+https://github.com/bitwarden/ai-plugins/tree/main/plugins/bitwarden-init
+
+Authoring guidance for everything else under .claude/ lives in
+.claude/CONTRIBUTING.md.
+-->
+
+Brief description of the project and its primary purpose.
+
+## Overview
+
+What this project does, key concepts, and target consumers.
+
+## Architecture & Patterns
+
+System architecture, code organization, key principles, and core patterns.
+
+## Development Guide
+
+Step-by-step instructions for the most common development tasks.
+
+## Data Models
+
+Core types and validation schemas.
+
+## Security & Configuration
+
+Security rules, environment configuration, and authentication.
+
+## Testing
+
+Test structure, writing tests, and running tests.
+
+## Code Style & Standards
+
+Formatting, naming conventions, and pre-commit hooks.
+
+## Anti-Patterns
+
+DO and DON'T lists.
+
+## Deployment
+
+Building, versioning, and publishing.
+
+## Troubleshooting
+
+Common issues and debug tips.
+
+## References
+
+Official documentation, internal documentation, and tools.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,35 @@
-# Template Repository
+# Repository name
 
-This repository serves as a template for others and establishes very basic structure and tooling setup for later customization.
+<!--
+Template guidance — delete this comment when customizing your new repo.
 
-## Hooks
+This README follows the documentation standard; fill the sections below and
+delete the ones marked optional that do not apply:
+https://contributing.bitwarden.com/contributing/documentation
+-->
+
+One or two sentences stating what this repository is and which products or systems it serves.
+
+## Getting started
+
+Build instructions and environment setup live in the
+[contributing documentation](https://contributing.bitwarden.com/getting-started/).
+
+<!-- Only repo-specific setup with no home on the site belongs below this line. -->
+
+## Structure
+
+<!-- Monorepos only; delete otherwise. One line per container or top-level component. -->
+
+| Container or component | Purpose |
+| ---------------------- | ------- |
+|                        |         |
+
+## Related repositories
+
+- [bitwarden/server](https://github.com/bitwarden/server) — replace with the repos this one interacts with
+
+## Git hooks
 
 Hooks are centrally configured for the repo in the `.gitconfig` file. The `pre-commit` hook
 ([`.githooks/pre-commit`](.githooks/pre-commit)) runs [Prettier](https://prettier.io) (`--check`) on
@@ -20,10 +47,12 @@ git config set --local include.path "../.gitconfig"
 Running the hook requires [Node.js](https://nodejs.org) (>=18); the tools are fetched on demand via
 `npx`.
 
-## Customizing the linter
+<!--
+Customizing the linter — delete this comment when customizing your new repo.
 
-Because this is a template, treat the linter as a starting point and adjust it for your repo. The file
-extensions are the most likely thing to change: Prettier checks Markdown, JSON, JSON5, and YAML, and
-CSpell checks Markdown. If you change those globs, update both
-[`.githooks/pre-commit`](.githooks/pre-commit) and the [Lint workflow](.github/workflows/lint.yml) so
-local commits and CI stay in sync. Swapping tools or changing the pinned versions works the same way.
+Treat the linter as a starting point. The file extensions are the most likely
+thing to change: Prettier checks Markdown, JSON, JSON5, and YAML, and CSpell
+checks Markdown. If you change those globs, update both .githooks/pre-commit
+and the Lint workflow so local commits and CI stay in sync. Swapping tools or
+changing the pinned versions works the same way.
+-->


### PR DESCRIPTION
## 📔 Objective

Ensure compliance with new README requirements from the get-go. ([see documentation standards PR](https://github.com/bitwarden/contributing-docs/pull/842))

This repository is only responsible for initializing repositories in a good state, so the actual long-term requirements of READMEs are kept in contributing-docs